### PR TITLE
docs: add user documentation, Sphinx site and README rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ htmlcov/
 # Temporary files
 temp/
 
+# Sphinx documentation build output
+docs/_build/
+
 # Package metadata
 src/*.egg-info/
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration for genro-asgi.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -1,24 +1,183 @@
-# Genro ASGI Core
+# genro-asgi
 
-**Minimal ASGI server core** — spec-first redesign of `genro-asgi`.
+**A minimal ASGI server core** — one instance-isolated server that mounts your
+applications, routes requests through [genro-routes](https://pypi.org/project/genro-routes/),
+and grows authentication, sessions, background tasks, OpenAPI and MCP by
+composition. No globals, no module state: the server is an object you build,
+run, and throw away.
 
-## Status
+[![PyPI version](https://img.shields.io/pypi/v/genro-asgi.svg)](https://pypi.org/project/genro-asgi/)
+[![Python versions](https://img.shields.io/pypi/pyversions/genro-asgi.svg)](https://pypi.org/project/genro-asgi/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-- **Development Status**: Alpha
-- This repository starts from a ratified design specification rather than
-  ported code. See `SPECIFICATION.md` for the founding decision log and
-  design rationale.
+> **Status: Beta.** Feature-complete core, API stabilizing. This repository is a
+> spec-first redesign — see [`SPECIFICATION.md`](SPECIFICATION.md) for the
+> founding decision log.
+
+## What it does
+
+- **Serves applications** — a required primary app answers `/`, secondary apps
+  mount on URL prefixes; the server demultiplexes on the first path segment.
+- **Routes requests** — handlers are `@route`-decorated methods on your
+  application class; query and body parameters bind to the signature, typed.
+- **Authenticates** — basic / bearer / JWT credentials, API keys (`gak_…`),
+  and OIDC providers; per-route `auth_rule` filtering, default-deny.
+- **Manages sessions** — in-memory or file-backed store, cookie reconnection,
+  `Avatar` identity (tags + extensible Bag data).
+- **Applies middleware** — errors, CORS, logging, auth, session, well-known —
+  composed as an ordered chain, each turned on by config.
+- **Runs background tasks** — a spool + executor + cron/interval scheduler,
+  managed over `/_server/tasks`.
+- **Generates OpenAPI & Swagger** — subclass `OpenApiApplication` and the same
+  `@route` methods yield an OpenAPI 3.1 schema and a Swagger UI.
+- **Speaks MCP** — subclass `McpApplication` (or `McpOpenApiApplication`) and
+  your routes become tools an AI agent can call, over MCP Streamable HTTP.
+- **Streams** — `StreamingResponse` for chunked bodies, `SseStream` for
+  Server-Sent Events.
+
+## Installation
+
+```bash
+pip install genro-asgi
+```
+
+Requires Python 3.11+.
+
+## Hello world
+
+One file. A `RoutedApplication` subclass with two `@route` handlers, served by
+an `AsgiServer`:
+
+```python
+# hello.py
+from genro_asgi import AsgiServer, RoutedApplication
+from genro_routes import route
+
+
+class Hello(RoutedApplication):
+    @route()
+    def index(self) -> dict[str, str]:
+        return {"hello": "world"}
+
+    @route()
+    def greet(self, name: str = "world") -> dict[str, str]:
+        return {"hello": name}
+
+
+if __name__ == "__main__":
+    server = AsgiServer(primary=Hello())
+    server.serve(host="127.0.0.1", port=8000)
+```
+
+```bash
+python hello.py
+```
+
+```console
+$ curl http://127.0.0.1:8000/index
+{"hello": "world"}
+$ curl "http://127.0.0.1:8000/greet?name=genro"
+{"hello": "genro"}
+```
+
+A handler that returns a `dict` answers JSON; the query string binds to the
+method signature (`name` above), with defaults and type coercion. An unknown
+path answers `404` through the always-on error middleware.
+
+## REST + OpenAPI + Swagger from one class
+
+Subclass `OpenApiApplication` instead of `RoutedApplication`, declare
+`openapi_info`, and enable the plugins — the same `@route` methods now expose an
+OpenAPI 3.1 schema and a Swagger UI, generated from their signatures:
+
+```python
+from genro_asgi import AsgiServer, OpenApiApplication
+from genro_routes import route
+
+
+class Shop(OpenApiApplication):
+    openapi_info = {"title": "Shop API", "version": "1.0.0"}
+
+    @route()
+    def search(self, q: str = "", max_price: float = 100.0) -> dict:
+        return {"query": q, "hits": []}
+
+
+server = AsgiServer(primary=Shop(), plugins={"openapi": True, "pydantic": True})
+server.serve(port=8000)
+```
+
+- `/search?q=moka&max_price=30` — the endpoint, params typed and coerced
+- `/_meta/docs` — the Swagger UI
+- `/_meta/schema_json` — the OpenAPI 3.1 document
+
+If you know FastAPI, this is the same decorate-a-method workflow. The difference
+is where the route description lives: genro-routes keeps it protocol-neutral, so
+other transports read the same tree. Switch the base class to
+`McpOpenApiApplication` and the app grows an MCP face on `/mcp` — the routes you
+mark with `@route(channel_channels="mcp")` become tools an agent can call, with
+the same parameter handling as REST. See
+[Coming from Starlette / FastAPI](docs/coming-from-fastapi.md) for a full
+concept mapping.
+
+## Architecture at a glance
+
+The server is an instance with its own state — no global variables. Every
+component is an isolated object connected by a semantic parent reference (an app
+holds `self.server`, a request holds `self.application`).
+
+```text
+uvicorn → AsgiServer → middleware chain (errors → cors → auth → session)
+  → demultiplex on first path segment → application
+    → @route handler(**params) → Response → ASGI send
+```
+
+`AsgiServer` is the shipped composition: it stacks the capability mixins
+(communication, auth, session, middleware, plugins, storage, tasks) over
+`BaseServer` in one MRO. You turn features on through constructor kwargs
+(`auth=…`, `middleware=…`, `tasks=…`, `plugins=…`) — objects always exist,
+their backends come from config.
+
+## Documentation
+
+Full documentation (guides, architecture, API reference) is built with Sphinx
+under [`docs/`](docs/) and published on Read the Docs.
+
+- [Getting started](docs/getting-started.md)
+- [Coming from Starlette / FastAPI](docs/coming-from-fastapi.md)
+- [Architecture overview](docs/architecture/overview.md)
+- [`SPECIFICATION.md`](SPECIFICATION.md) — the founding decision log
+
+Build it locally:
+
+```bash
+pip install -e ".[docs]"
+sphinx-build -b html docs docs/_build/html
+```
+
+## Development
+
+```bash
+git clone https://github.com/genropy/genro-asgi.git
+cd genro-asgi
+pip install -e ".[dev]"
+
+pytest                    # run tests
+ruff check src/           # lint
+mypy src/                 # type check (advisory)
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow.
 
 ## License
 
-This project is licensed under the **Apache License 2.0**.
+Copyright © 2025 **Softwell S.r.l.**
 
-Copyright © 2025
-**Softwell S.r.l.**
+Licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+This project may include third-party components under separate open-source
+licenses; see the [`NOTICE`](NOTICE) file for attribution.
 
-You may obtain a copy of the license at:
+## Links
 
-https://www.apache.org/licenses/LICENSE-2.0
-
-This project may include third-party components distributed under separate open-source licenses.
-See the `NOTICE` file for additional attribution.
+- **GitHub**: <https://github.com/genropy/genro-asgi>
+- **PyPI**: <https://pypi.org/project/genro-asgi/>

--- a/docs/api/applications.rst
+++ b/docs/api/applications.rst
@@ -1,0 +1,49 @@
+Applications
+============
+
+The mountable application classes: OpenAPI, MCP, and the automatic ``_server``
+application with its sections.
+
+OpenAPI
+-------
+
+.. automodule:: genro_asgi.applications.openapi
+   :members:
+   :show-inheritance:
+
+MCP
+---
+
+.. automodule:: genro_asgi.applications.mcp
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.mcp.engine
+   :members:
+   :show-inheritance:
+
+Server application
+------------------
+
+.. automodule:: genro_asgi.applications.server_app
+   :members:
+   :show-inheritance:
+
+Server sections
+---------------
+
+.. automodule:: genro_asgi.applications.server_sections.auth_section
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.applications.server_sections.users_section
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.applications.server_sections.tokens_section
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.applications.server_sections.tasks_section
+   :members:
+   :show-inheritance:

--- a/docs/api/auth.rst
+++ b/docs/api/auth.rst
@@ -1,0 +1,29 @@
+Authentication
+==============
+
+The auth mixin, the credential core, the auth methods (password, OIDC), and the
+identity stores.
+
+.. automodule:: genro_asgi.auth.mixin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.auth.core
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.auth.auth_method
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.auth.oidc_method
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.auth.user_store
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.auth.api_key_store
+   :members:
+   :show-inheritance:

--- a/docs/api/channel.rst
+++ b/docs/api/channel.rst
@@ -1,0 +1,16 @@
+Channel and communication
+=========================
+
+The parent-child channel (client and frame) and the communication mixin.
+
+.. automodule:: genro_asgi.communication
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.channel.client
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.channel.frame
+   :members:
+   :show-inheritance:

--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,32 @@
+Configuration
+=============
+
+The config builder, the configuration handler, and the config-as-data
+machinery (elements, projection).
+
+.. automodule:: genro_asgi.config.builder
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.config.handler
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.config.configurable
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.config.elements
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.config.projection
+   :members:
+   :show-inheritance:
+
+Database handler
+----------------
+
+.. automodule:: genro_asgi.db
+   :members:
+   :show-inheritance:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,0 +1,71 @@
+Core
+====
+
+The server, the application contract, request/response, and the shared types.
+
+Server
+------
+
+.. automodule:: genro_asgi.server
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.asgi_server
+   :members:
+   :show-inheritance:
+
+Applications (contract)
+-----------------------
+
+.. automodule:: genro_asgi.application
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.routed_application
+   :members:
+   :show-inheritance:
+
+Request and response
+--------------------
+
+.. automodule:: genro_asgi.request
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.response
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.streaming
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.sse
+   :members:
+   :show-inheritance:
+
+Registry, lifespan and pool
+---------------------------
+
+.. automodule:: genro_asgi.registry
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.lifespan
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.pool
+   :members:
+   :show-inheritance:
+
+Exceptions and types
+--------------------
+
+.. automodule:: genro_asgi.exceptions
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.types
+   :members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,20 @@
+API Reference
+=============
+
+The API reference is generated from the source docstrings. Every public symbol
+exported from ``genro_asgi`` is documented on the pages below, grouped by
+subsystem.
+
+.. toctree::
+   :maxdepth: 2
+
+   core
+   applications
+   auth
+   session
+   middleware
+   tasks
+   config
+   channel
+   storage
+   plugins

--- a/docs/api/middleware.rst
+++ b/docs/api/middleware.rst
@@ -1,0 +1,37 @@
+Middleware
+==========
+
+The middleware base and mixin, and the shipped middleware: errors, well-known,
+logging, CORS, authentication, session.
+
+.. automodule:: genro_asgi.middleware
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.base
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.errors
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.wellknown
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.logging
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.cors
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.authentication
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.middleware.session
+   :members:
+   :show-inheritance:

--- a/docs/api/plugins.rst
+++ b/docs/api/plugins.rst
@@ -1,0 +1,16 @@
+Plugins
+=======
+
+The plugin mixin and the OpenAPI plugin (router integration and translator).
+
+.. automodule:: genro_asgi.plugin_mixin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.plugins.openapi.plugin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.plugins.openapi.translator
+   :members:
+   :show-inheritance:

--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -1,0 +1,24 @@
+Sessions
+========
+
+The session mixin, the session object, the avatar, and the session stores.
+
+.. automodule:: genro_asgi.session.mixin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.session.session
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.session.avatar
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.session.store
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.session.file_store
+   :members:
+   :show-inheritance:

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -1,0 +1,12 @@
+Storage
+=======
+
+The storage mixin and the local filesystem storage with its mount system.
+
+.. automodule:: genro_asgi.storage_mixin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.storage
+   :members:
+   :show-inheritance:

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -1,0 +1,36 @@
+Tasks
+=====
+
+The task mixin and manager, the spool, executor, scheduler and stores.
+
+.. automodule:: genro_asgi.tasks.mixin
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.manager
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.spool
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.executor
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.scheduler
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.schedule
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.store
+   :members:
+   :show-inheritance:
+
+.. automodule:: genro_asgi.tasks.hub
+   :members:
+   :show-inheritance:

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,104 @@
+# Architecture overview
+
+> **Status:** 🔴 DA REVISIONARE
+
+This page explains how genro-asgi is put together and the principles behind it.
+It is *explanation*, not a how-to: read it to understand why the pieces are
+shaped the way they are. The normative source is
+[`SPECIFICATION.md`](https://github.com/genropy/genro-asgi/blob/main/SPECIFICATION.md)
+(the decision log, D1…); this page summarizes it and never contradicts it.
+
+## Core principles
+
+These are the guiding principles of the redesign (SPECIFICATION.md §1). They
+explain most of the design decisions you will meet in the code.
+
+- **No globals.** The server is an instance with its own state — no module-level
+  variables, no singletons. `del server` garbage-collects everything it owns.
+  State lives in objects, connected by semantic parent references.
+- **Config is data, not structure.** What a server *is* comes from a
+  configuration recipe rendered onto it; the code shape does not change with the
+  deployment.
+- **Objects always exist; backends come from config.** There is no `X | None`
+  attribute flipped on by a flag. The session store, the auth core, the task
+  manager are always there — their *backend* is what configuration selects.
+- **Work at the time of use.** Expensive machinery (the thread pool, the task
+  manager) is provisioned lazily, on first use.
+- **Routes are static from boot.** The routing tree is built once; routing is
+  never used as a mutable registry.
+- **Extension by subclassing; capabilities as mixins.** You add behaviour by
+  subclassing an application, and the server composes capabilities (auth,
+  session, tasks…) as mixins over a base.
+
+## The request flow
+
+```text
+uvicorn
+  → AsgiServer                      the server IS the ASGI app
+    → middleware chain              errors → cors → auth → session (ordered)
+      → demultiplex                 first path segment → mount, else primary
+        → application               a RoutedApplication (or a subclass)
+          → @route handler(**params)
+            → Response              buffered, or a StreamingResponse
+              → ASGI send
+```
+
+Middleware order is a number, not a class trait: the chain sorts by it, smaller
+is more outer. Only `errors` is on by default; `session` and `auth` are armed by
+their mixins when you configure them.
+
+## The two layers: server and application
+
+genro-asgi separates *what the server owns* from *what an application does*.
+
+### BaseServer
+
+`BaseServer` is the common substrate of every server (SPECIFICATION.md §4, D2).
+It owns: one uvicorn loop, one monitored thread pool for blocking work, the
+**primary application** (always present, answers `/` and everything no mount
+claims), the **secondary mounts** (a dict of apps keyed by URL prefix), the
+lifespan (ordered startup/shutdown), and the request registry. At the base,
+`authenticate()` and `session()` answer "nobody / none" — auth and sessions are
+capabilities layered on top, not built into the base.
+
+The one dispatch rule (D3) is: **first path segment → a secondary mount if one
+claims it, otherwise the primary app.** A single-app server is just a base
+server used with only its primary — there is no separate mechanism.
+
+### AsgiServer
+
+`AsgiServer` is the shipped composition (D22): it stacks every capability mixin
+over `BaseServer` in one MRO — communication, auth, session, middleware,
+plugins, storage, tasks. This is the complete mono-process async server. You
+turn a capability on through a constructor kwarg (`auth=…`, `middleware=…`,
+`tasks=…`, `plugins=…`); the mixin peels the kwargs it understands and forwards
+the rest down the cooperative `__init__` chain.
+
+Because auth is a mixin and not part of the base, an internal (non-public)
+server can compose the *same* base **without** the auth mixin — its auth and
+sessions are `None` by design, and whoever fronts it owns them (D1, D6).
+
+### BaseApplication and RoutedApplication
+
+`BaseApplication` is the app-side contract: an ASGI callable with a
+`mount_name` and a `server` reference assigned once by the owning server at
+attach time (a second assignment raises). `RoutedApplication` wires
+[genro-routes](https://pypi.org/project/genro-routes/) into it: handlers are
+`@route`-decorated methods, resolved through the app's own router. The
+`OpenApiApplication`, `McpApplication` and `McpOpenApiApplication` subclasses add
+protocol faces (OpenAPI/Swagger, MCP) over the *same* route tree — which is why
+one decorated method can serve REST and MCP at once.
+
+## The automatic `_server` application
+
+Every `AsgiServer` auto-mounts a `ServerApplication` at `/_server` (D4). It
+exposes the server's own management surface — login, users, tokens, tasks —
+under `/_server/…`, and its OpenAPI schema at `/_server/_meta/schema_json`. It
+is *automatic, not configured*: a hand-built server has it exactly like a
+config-materialized one.
+
+## Where to go next
+
+- [Getting started](../getting-started.md) — install and run.
+- [Concepts](../concepts.md) — the model in more practical terms.
+- [`SPECIFICATION.md`](https://github.com/genropy/genro-asgi/blob/main/SPECIFICATION.md) — the full decision log.

--- a/docs/coming-from-fastapi.md
+++ b/docs/coming-from-fastapi.md
@@ -1,0 +1,133 @@
+# Coming from Starlette / FastAPI
+
+> **Status:** 🔴 DA REVISIONARE
+
+If you already know Starlette or FastAPI, genro-asgi will feel familiar in the
+small — you still decorate a callable to make a route, params still bind to the
+signature, and you still get OpenAPI and Swagger for free. It differs in the
+large: in *what you build* and *how features appear*. This page maps the two so
+you can carry your intuition across and know where it stops.
+
+## The mental model, side by side
+
+**FastAPI** gives you an application object; you attach path operations to it with
+function decorators, and a dependency-injection container supplies each operation
+with what it declares. Middleware and security are attached to the app; you run it
+under uvicorn.
+
+**genro-asgi** gives you a *server that mounts applications*. An application is a
+class whose `@route`-decorated **methods** are its endpoints. The server itself is
+a **composition of capability mixins** — auth, sessions, tasks, plugins — that
+always exist and are fed by **config data** rather than switched on structurally.
+There is no dependency-injection container: a handler reaches what it needs
+through the object graph (its application, the server, the request), not through
+declared dependencies. You start the server by calling `.serve()` from your own
+entry point — there is no dedicated command-line launcher.
+
+The other pivotal difference is that routing is **protocol-neutral**. In FastAPI a
+path operation is an HTTP thing. In genro-asgi a `@route` describes an operation
+independently of transport, which is exactly why the *same* method tree can be
+served as REST, as an OpenAPI schema, and as MCP tools without being rewritten.
+
+## Concept mapping
+
+| Task | FastAPI / Starlette | genro-asgi |
+|------|---------------------|------------|
+| Create the app | `app = FastAPI()` | subclass `RoutedApplication` (or `OpenApiApplication`); build `AsgiServer(primary=App())` |
+| Define a route | `@app.get("/greet")` on a function | `@route()` on a **method** (name = URL segment), imported from `genro_routes` |
+| Path / query params | function args + `Path`/`Query` | method args bind to the query string, typed, with defaults |
+| Request body / validation | pydantic model as a param | the `pydantic` plugin (`plugins={"pydantic": True}`) |
+| JSON response | `return {...}` / `JSONResponse` | `return {...}` (dict → JSON) |
+| HTML response | `HTMLResponse` | `@route(media_type="text/html")` returning a string |
+| Dependency injection | `Depends(...)` | no DI container — reach through the object graph (`self.server`, the request) |
+| Middleware | `app.add_middleware(...)` | `middleware={...}` kwarg on `AsgiServer`; ordered built-in chain |
+| Auth / security | `Security(...)`, security schemes | `auth={...}` kwarg + `@route(auth_rule="...")`, default-deny, `Avatar` |
+| Sessions | `SessionMiddleware` (Starlette) | `SessionMixin` via `session_store`/`session_ttl`; `Session` + `Avatar` |
+| Mount a sub-app | `app.mount("/api", subapp)` | secondary mounts (dict by URL prefix); demux on first path segment |
+| OpenAPI / Swagger | automatic at `/docs`, `/openapi.json` | `OpenApiApplication` + plugins; `/_meta/docs`, `/_meta/schema_json` |
+| Start the server | `uvicorn.run(app, ...)` / `uvicorn app:app` | `server.serve(host=..., port=...)` (programmatic uvicorn, blocking) |
+| WebSocket / streaming | `WebSocket`, `StreamingResponse` | `StreamingResponse` (from `genro_asgi.streaming`), `SseStream` (from `genro_asgi.sse`) |
+| Tools for an AI agent | (not built in) | `@route(channel_channels="mcp")` on an `McpApplication` / `McpOpenApiApplication` |
+
+## The same endpoint, side by side
+
+A tiny search endpoint with a typed query parameter, returning JSON, documented in
+OpenAPI.
+
+**FastAPI** — shown *for comparison only*, illustrative:
+
+```python
+# For comparison — this is FastAPI, not genro-asgi.
+from fastapi import FastAPI
+
+app = FastAPI(title="Shop API", version="1.0.0")
+
+
+@app.get("/search")
+def search(q: str = "", max_price: float = 100.0) -> dict:
+    return {"query": q, "hits": []}
+
+# uvicorn module:app --port 8000
+```
+
+**genro-asgi** — real, verified API:
+
+```python
+from genro_asgi import AsgiServer, OpenApiApplication
+from genro_routes import route
+
+
+class Shop(OpenApiApplication):
+    openapi_info = {"title": "Shop API", "version": "1.0.0"}
+
+    @route()
+    def search(self, q: str = "", max_price: float = 100.0) -> dict:
+        return {"query": q, "hits": []}
+
+
+server = AsgiServer(primary=Shop(), plugins={"openapi": True, "pydantic": True})
+server.serve(host="127.0.0.1", port=8000)
+```
+
+Both answer `GET /search?q=moka&max_price=30`. The FastAPI version documents at
+`/docs` and `/openapi.json`; the genro-asgi version at `/_meta/docs` and
+`/_meta/schema_json`. The visible difference is small — a method on a class
+instead of a free function, and a server that mounts the app instead of *being*
+the app. The invisible difference is the one that matters: switch the base class
+to `McpOpenApiApplication` and mark `search` with
+`@route(channel_channels="mcp,rest")`, and the same method is now both a REST
+endpoint and an MCP tool.
+
+## Honest notes on the differences
+
+- **No dependency-injection container.** There is no `Depends`. Handlers reach
+  collaborators through the object graph — the application holds `self.server`, the
+  request holds `self.application`. If you lean heavily on FastAPI's DI for
+  wiring, that pattern does not port; you compose objects instead.
+- **No dedicated CLI.** There is no `genro-asgi serve` command and no `.run()`
+  method. You write a Python entry point that builds the server and calls
+  `.serve()`, which boots a programmatic uvicorn loop and blocks. `port=0` asks the
+  OS for a free port (useful in tests).
+- **Routing is protocol-neutral by design.** A `@route` is not inherently an HTTP
+  operation. That is the reason REST, OpenAPI and MCP share one route tree — and
+  the reason a method only becomes an MCP tool when you opt it in with
+  `channel_channels`. The flip side: think of a route as "an operation", not "an
+  HTTP verb on a path".
+- **Features are config, not construction.** You do not add a capability by
+  restructuring code; auth, sessions, tasks and plugins already exist on
+  `AsgiServer` and are fed by kwargs (`auth=...`, `middleware=...`, `tasks=...`,
+  `plugins=...`). A capability you did not configure is present but idle, not
+  absent.
+- **The OpenAPI prefix is `_meta`.** Not `/docs` and `/openapi.json` — the Swagger
+  UI is at `/_meta/docs` and the schema at `/_meta/schema_json`.
+- **An internal `_server` app is always mounted.** Login, task management and the
+  system OpenAPI live under `/_server/...` with no setup on your part — there is no
+  FastAPI equivalent you need to wire up.
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — the runnable hello-world.
+- **[Core concepts](concepts.md)** — the server/application model and the demux
+  rule in full.
+- **[How-to guides](guides/index.md)** — auth, sessions, OpenAPI, MCP, tasks,
+  streaming, middleware.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,196 @@
+# Core Concepts
+
+> **Status:** 🔴 DA REVISIONARE
+
+This page explains the model behind genro-asgi: how a server relates to the
+applications it serves, how a request finds its handler, and the design
+principles that make the whole thing predictable. Read it once and the how-to
+guides will read like footnotes.
+
+## The server / application model
+
+genro-asgi separates two roles cleanly:
+
+- A **server** owns the runtime: one uvicorn loop, the middleware chain, the
+  request registry, lifespan, and the set of applications it serves.
+- An **application** owns behaviour: a tree of `@route`-decorated methods that
+  answer requests. An application knows nothing about ports or middleware.
+
+### `BaseServer` and `AsgiServer`
+
+`BaseServer` is the minimal substrate every server shares: the uvicorn loop, a
+monitored thread pool for blocking work, the primary app, the secondary mounts,
+lifespan, and the request registry.
+
+`AsgiServer` is the shipped, batteries-included server. It is a **composition of
+capability mixins** stacked over `BaseServer` in a single MRO — communication,
+auth, session, middleware, plugins, storage, and tasks. Each mixin contributes a
+feature, and each feature is turned on through a constructor keyword argument:
+
+```python
+server = AsgiServer(
+    primary=App(),
+    auth={...},          # arms the auth middleware
+    middleware={...},    # arms other middleware
+    tasks=True,          # arms the task backbone
+    plugins={...},       # arms OpenAPI / pydantic plugins
+)
+```
+
+The mixins exist whether or not you configure them — you never subclass to *add*
+a capability, you pass config to *feed* it. This is what "objects always exist,
+backends come from config" means in practice.
+
+### Primary vs mounts
+
+A server always has exactly one **primary** application (mandatory) and a
+dictionary of **secondary mounts** keyed by URL prefix (possibly empty).
+
+- The **primary** answers `/` and everything no mount claims.
+- A **secondary mount** answers requests whose first path segment matches its
+  mount name.
+
+```python
+# Conceptual shape: a primary "shop" plus a secondary "api" mount.
+# Requests to /api/... reach the api app; everything else reaches shop.
+```
+
+### The one demux rule
+
+There is a single rule for dispatching a request to an application, the same on
+every server:
+
+> **First path segment → secondary mount if one exists with that name,
+> otherwise the primary app.**
+
+Running with only a primary and no mounts is a *usage* of this rule, not a
+different mechanism. There is no second dispatch path to learn.
+
+### The automatic `_server` app
+
+Every server automatically mounts an internal application at `/_server/`. You do
+not configure it into existence — it is always present. On a public server it is
+**full** (login, monitoring, OpenAPI of the system endpoints, task management);
+its endpoints live under `/_server/...` and never leak into your own app's route
+tree.
+
+## Routing with genro-routes
+
+Routing is delegated to **genro-routes**, a protocol-neutral routing library.
+This is a deliberate choice: because the route tree does not know whether it is
+being called over REST, OpenAPI, or MCP, the *same* tree can be exposed through
+several transports. It is the reason OpenAPI and MCP applications reuse your
+ordinary `@route` methods rather than duplicating them.
+
+### `@route`
+
+Import the decorator from `genro_routes`:
+
+```python
+from genro_routes import route
+```
+
+Key forms you will use across the guides:
+
+- `@route()` — publish a method as an endpoint; its name is the URL segment.
+- `@route(media_type="text/html")` — respond as HTML instead of JSON.
+- `@route(auth_rule="admin")` — protect the endpoint (see below).
+- `@route(channel_channels="mcp")` — also expose the method as an MCP tool.
+- `@route(task="cleanup", task_every="1s")` — register the method as a scheduled
+  task.
+
+### `auth_rule` and default-deny
+
+A route carrying `auth_rule="admin"` is protected: the caller's avatar must carry
+the matching tag. Protection is **default-deny** — a protected route answers
+`403` even when no auth middleware is configured, so you never accidentally ship
+an open endpoint that was meant to be closed. The [authentication
+guide](guides/authentication.md) covers the credential side.
+
+## Requests and responses
+
+- A `Request` object wraps the incoming ASGI scope: query parameters bind to your
+  handler's signature, and the body is available for parsing.
+- A handler's **return value** determines the response: return a `dict` for JSON,
+  a string with `media_type="text/html"` for HTML, or an explicit `Response`
+  object for full control.
+- For long or open-ended bodies, return a `StreamingResponse` or an `SseStream`
+  (see the [streaming guide](guides/streaming.md)).
+
+Both `Request` and `Response` are importable from `genro_asgi`.
+
+## Design principles
+
+genro-asgi is a spec-first redesign; its principles are ratified in
+`SPECIFICATION.md`. Three of them govern almost every API decision:
+
+- **No globals — state lives in instances.** There is no module-level server and
+  no ambient request. A server is an object you build; its components reach each
+  other through an explicit parent reference (an application holds
+  `self.server`, a request holds `self.application`). Two servers in the same
+  process are fully isolated.
+- **Config is data, not structure.** You describe what you want with plain data
+  (dicts, config-builder calls) and hand it to objects that already exist. You do
+  not restructure code to switch a backend; you change the data.
+- **Objects always exist; backends come from config.** A capability is not an
+  `X | None` that a flag flips on. The session subsystem, the auth subsystem, the
+  task subsystem — they are always present. Configuration decides which backend
+  they use. This removes a whole category of "is it enabled?" branching.
+
+Two more shape how you extend the framework:
+
+- **Routes are static from boot** — the route tree is fixed when the server
+  starts; routing is never used as a mutable registry.
+- **Extension is by subclassing.** You grow an application by subclassing the
+  right base (`OpenApiApplication`, `McpApplication`, `SessionMixin`, and so on),
+  not by patching instances at runtime.
+
+## The request flow
+
+Putting it together, here is the path an HTTP request travels:
+
+```text
+        HTTP request
+             │
+             ▼
+        ┌─────────┐
+        │ uvicorn │            one loop, owned by the server
+        └────┬────┘
+             ▼
+      ┌────────────┐
+      │ AsgiServer │           the ASGI app is the server object itself
+      └─────┬──────┘
+            ▼
+  ┌───────────────────────┐
+  │   middleware chain      │  errors → (wellknown) → (logging) →
+  │  (outer → inner)        │  (cors) → (session) → (auth)
+  └───────────┬────────────┘
+              ▼
+     ┌──────────────────┐
+     │  demux on first   │    segment matches a mount?  → that app
+     │  path segment     │    otherwise                → primary app
+     └────────┬──────────┘
+              ▼
+   ┌────────────────────────┐
+   │  @route handler(**params)│  query/body bound to the signature, typed
+   └───────────┬────────────┘
+               ▼
+          ┌──────────┐
+          │ Response │           dict → JSON, str+html → HTML, stream → chunks
+          └────┬─────┘
+               ▼
+          ASGI send  ───────────►  HTTP response
+```
+
+The middleware are ordered by priority (lower number = more outer). The
+always-on error middleware wraps everything, which is why an unmatched path or a
+raised HTTP exception becomes a clean status code rather than a stack trace. See
+the [middleware guide](guides/middleware.md) for the exact chain and how to arm
+each stage.
+
+## Where to go next
+
+- **[How-to guides](guides/index.md)** — apply these concepts to concrete tasks.
+- **[Getting started](getting-started.md)** — if you skipped the runnable
+  hello-world, start there.
+- `SPECIFICATION.md` — the founding decision log, for the full rationale.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Softwell S.r.l.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sphinx configuration for the genro-asgi documentation."""
+
+import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+# The package is expected to be installed (``pip install -e ".[docs]"``); add
+# ``src`` to the path as a fallback so autodoc resolves imports either way.
+sys.path.insert(0, str(Path("..").resolve() / "src"))
+
+project = "genro-asgi"
+copyright = "2025-2026, Softwell S.r.l."
+author = "Genropy Team"
+try:
+    release = _pkg_version("genro-asgi")
+except PackageNotFoundError:
+    release = "0.0.0.dev0"
+version = release
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+    "myst_parser",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# MyST: the guides and narrative pages are Markdown; the toctree skeleton is rst.
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+myst_heading_anchors = 3
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+# Napoleon: the codebase uses Google-style docstrings.
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+napoleon_include_init_with_doc = True
+
+# Autodoc: document members in source order; keep the ``__init__`` convention
+# (kwargs live in the class docstring) readable.
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,196 @@
+# Getting Started
+
+> **Status:** 🔴 DA REVISIONARE
+
+Welcome to **genro-asgi**. This page takes you from installation to a running
+server that answers real HTTP requests, then explains the hello-world line by
+line so you know *why* each piece is there before you reach for anything more
+advanced.
+
+## What genro-asgi is
+
+genro-asgi is a **minimal ASGI server core**. You build one server object, mount
+your applications on it, and it routes incoming requests to `@route`-decorated
+methods on those applications. Everything else — authentication, sessions,
+background tasks, OpenAPI, MCP, streaming — grows on the same core by
+composition, turned on through constructor keyword arguments.
+
+Two ideas shape the whole design:
+
+- **The server is an object.** You construct an `AsgiServer`, call `.serve()`,
+  and throw it away. There are no global variables and no module-level state; a
+  test can spin up a fresh isolated server on every run.
+- **Configuration is data.** Features do not appear and disappear — the objects
+  always exist. What changes is the config you hand them (a backend, a set of
+  credentials, a middleware option). You never flip a feature on by monkey-
+  patching; you describe it.
+
+If you come from Starlette or FastAPI, the decorate-a-handler workflow will feel
+familiar; the differences are covered in
+[Coming from Starlette / FastAPI](coming-from-fastapi.md).
+
+## Installation
+
+```bash
+pip install genro-asgi
+```
+
+Requires Python 3.11+.
+
+## Hello world
+
+One file. A `RoutedApplication` subclass with two `@route` handlers, served by
+an `AsgiServer`:
+
+```python
+# hello.py
+from genro_asgi import AsgiServer, RoutedApplication
+from genro_routes import route
+
+
+class Hello(RoutedApplication):
+    @route()
+    def index(self) -> dict[str, str]:
+        return {"hello": "world"}
+
+    @route()
+    def greet(self, name: str = "world") -> dict[str, str]:
+        return {"hello": name}
+
+
+if __name__ == "__main__":
+    server = AsgiServer(primary=Hello())
+    server.serve(host="127.0.0.1", port=8000)
+```
+
+Run it:
+
+```bash
+python hello.py
+```
+
+And call it:
+
+```console
+$ curl http://127.0.0.1:8000/index
+{"hello": "world"}
+$ curl "http://127.0.0.1:8000/greet?name=genro"
+{"hello": "genro"}
+$ curl "http://127.0.0.1:8000/greet"
+{"hello": "world"}
+$ curl -i http://127.0.0.1:8000/nowhere
+HTTP/1.1 404 Not Found
+```
+
+## Line by line
+
+Every line above earns its place. Here is what each one does.
+
+### The primary application
+
+```python
+class Hello(RoutedApplication):
+```
+
+`RoutedApplication` is the base class for an application whose behaviour is
+described by `@route`-decorated methods. Your subclass *is* the application: its
+methods are its endpoints.
+
+### The `@route` decorator
+
+```python
+from genro_routes import route
+
+@route()
+def index(self) -> dict[str, str]:
+    return {"hello": "world"}
+```
+
+`route` is imported from **genro-routes**, the protocol-neutral routing library
+genro-asgi builds on. It is *not* re-exported from `genro_asgi`, so import it
+directly from `genro_routes`.
+
+Marking a method with `@route()` publishes it as an endpoint. The method name
+becomes the URL segment: `index` answers `GET /index`, `greet` answers
+`GET /greet`. Returning a `dict` produces a JSON response automatically.
+
+### Query parameters bind to the signature
+
+```python
+@route()
+def greet(self, name: str = "world") -> dict[str, str]:
+    return {"hello": name}
+```
+
+Parameters in the method signature bind to the request's query string, typed and
+with defaults. `GET /greet?name=genro` calls `greet(name="genro")`; `GET /greet`
+with no query string uses the default `"world"`. The annotation drives coercion —
+declare `max_price: float` and the incoming string is converted to a float
+before your method runs.
+
+### Building and serving
+
+```python
+server = AsgiServer(primary=Hello())
+server.serve(host="127.0.0.1", port=8000)
+```
+
+`AsgiServer(primary=...)` builds the server. The **primary** application is
+mandatory — it answers `/` and every path no mounted app claims. Omitting it is
+an error.
+
+`server.serve(host=..., port=...)` boots a programmatic uvicorn loop and
+**blocks** until the process stops. The server object *is* the ASGI application
+handed to uvicorn — there is no separate app callable to wire up.
+
+> There is no `.run()` method and there is no command-line launcher. You start
+> the server by calling `.serve()` from your own Python entry point. Passing
+> `port=0` lets the OS assign a free port, which is handy in tests.
+
+## Responding with JSON or HTML
+
+A handler that returns a `dict` answers **JSON**. To answer **HTML**, declare the
+media type on the route and return a string:
+
+```python
+class Pages(RoutedApplication):
+    @route()
+    def data(self) -> dict:
+        return {"ok": True}          # application/json
+
+    @route(media_type="text/html")
+    def home(self) -> str:
+        return "<h1>Welcome</h1>"    # text/html
+```
+
+## The automatic 404
+
+You did not write a handler for `/nowhere`, yet the server answered `404` cleanly
+rather than crashing. That is the **error middleware**, which is on by default. It
+maps an unmatched path to `HTTPNotFound` and turns raised HTTP exceptions into
+proper responses. You will meet the rest of the middleware chain in the
+[middleware guide](guides/middleware.md).
+
+## The always-present `_server` app
+
+Every server, even a hand-built one like the hello-world above, automatically
+mounts an internal `_server` application at `/_server/`. It exposes system
+endpoints — login, task management, and (on request) a Swagger view of those
+endpoints. You do not configure it; it is always there. See the
+[authentication](guides/authentication.md) and [tasks](guides/tasks.md) guides
+for what lives under it.
+
+## Next steps
+
+- **[Core concepts](concepts.md)** — the server/application model, the demux
+  rule, routing, and the design principles behind them.
+- **[How-to guides](guides/index.md)** — task-focused recipes:
+  [authentication](guides/authentication.md),
+  [sessions](guides/sessions.md),
+  [OpenAPI & Swagger](guides/openapi.md),
+  [MCP](guides/mcp.md),
+  [background tasks](guides/tasks.md),
+  [streaming & SSE](guides/streaming.md),
+  [middleware](guides/middleware.md).
+- **[Coming from Starlette / FastAPI](coming-from-fastapi.md)** — a concept
+  mapping and side-by-side example if you already know those frameworks.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,0 +1,152 @@
+# Authentication
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Configures how callers prove who they are and controls which routes they may
+reach. genro-asgi accepts basic, bearer and JWT credentials plus API keys, and
+filters routes by the tags carried on the caller's `Avatar`.
+
+## When to use it
+
+When some routes must be restricted to authenticated callers, or to callers with
+a particular role. Pass an `auth` config to `AsgiServer` and mark the protected
+routes with `auth_rule`.
+
+## Setup
+
+Auth is a mixin capability of `AsgiServer`. You arm it by passing the `auth`
+keyword argument; doing so wires the auth middleware automatically.
+
+```python
+from genro_asgi import AsgiServer, RoutedApplication
+from genro_routes import route
+
+AUTH = {
+    "basic":  {"alice": {"password": "wonderland", "tags": "admin,ops"}},
+    "bearer": {"svc":   {"token": "sk_live_xyz", "tags": "api"}},
+    "jwt":    [{"secret": "topsecret", "algorithm": "HS256"}],
+}
+
+
+class App(RoutedApplication):
+    @route()
+    def public(self) -> dict:
+        return {"open": True}
+
+    @route(auth_rule="admin")
+    def secret(self) -> dict:
+        return {"classified": True}
+
+
+server = AsgiServer(primary=App(), auth=AUTH)
+server.serve(host="127.0.0.1", port=8000)
+```
+
+Notes on the config shape:
+
+- `basic` and `bearer` are dictionaries keyed by identity. A basic entry carries
+  a `password`; a bearer entry carries a `token`. Both carry `tags` (a
+  comma-separated string or a list) that become the avatar's roles.
+- `jwt` is a **list** of verifier configurations, each with a `secret` and an
+  `algorithm` — you can accept tokens from more than one issuer.
+- API keys with the `gak_...` prefix are handled by an `ApiKeyStore`. Pass
+  `tokens=<ApiKeyStore | dict>` alongside `auth`. Users can likewise come from a
+  `UserStore` via `users=<UserStore | dict>`, and an `admin_password="..."`
+  bootstraps a SUPERADMIN identity.
+
+## Minimal snippet
+
+Protecting a single route:
+
+```python
+@route(auth_rule="admin")
+def secret(self) -> dict:
+    return {"classified": True}
+```
+
+`auth_rule="admin"` means the caller's avatar must carry the `admin` tag.
+Protection is **default-deny**: this route answers `403` even if no auth is
+configured at all, so a protected endpoint is never accidentally open.
+
+## The Avatar
+
+An authenticated caller is represented by an `Avatar`:
+
+```python
+from genro_asgi import Avatar
+
+avatar = Avatar("alice", tags="admin,ops")   # tags: comma string or list
+```
+
+The avatar's tags are what `auth_rule` matches against. The same `Avatar` type is
+used whether the identity came from a header credential or from a session (see
+the [sessions guide](sessions.md)).
+
+## Header vs session precedence
+
+- The `Authorization` header wins — genro-asgi is API-first. If a request carries
+  a valid credential in the header, that identity is used.
+- An **invalid** header credential produces `401` with no fallback to the session
+  — a broken token is an error, not an invitation to try the cookie.
+- With `auth=None`, no header backend is configured, but the server still
+  resolves the identity carried by the session.
+
+## Server-side login flow
+
+The always-mounted `_server` app exposes a login flow for session-based clients:
+
+- `POST /_server/login` with body `{"identity", "password"}` → `200` with
+  `{identity, tags, session_id}` on success.
+- `GET /_server/login_page` — an HTML login page.
+- `GET /_server/login_methods` — a public JSON descriptor of available methods.
+- `POST /_server/logout`.
+
+Login lockout with backoff is configurable via `server_app={"login": {...}}`.
+
+## OIDC
+
+An OIDC provider is configured under `server_app`:
+
+```python
+PROVIDER = {
+    "issuer": "https://accounts.example.com",
+    "client_id": "client-123",
+    "scopes": "openid email profile",
+    "identity_claim": "email",
+    "tags": [],
+}
+server = AsgiServer(primary=App(), server_app={"oidc": {"google": PROVIDER}})
+```
+
+- `GET /_server/auth/oidc:google/start?next=...` → `302` (PKCE S256).
+- `GET /_server/auth/oidc:google/callback?...` → token exchange, avatar attach,
+  redirect.
+- The public descriptor never exposes the `client_secret` or the `issuer`.
+
+## How to verify it
+
+```console
+$ curl -i http://127.0.0.1:8000/secret
+HTTP/1.1 403 Forbidden
+
+$ curl -u alice:wonderland http://127.0.0.1:8000/secret
+{"classified": true}
+
+$ curl -H "Authorization: Bearer sk_live_xyz" http://127.0.0.1:8000/public
+{"open": true}
+```
+
+## Gotchas
+
+- `auth_rule` is default-deny: a protected route is `403` even with no auth
+  configured. If a route unexpectedly returns `403`, check whether it carries an
+  `auth_rule` the caller's avatar does not satisfy.
+- `jwt` is a **list**, not a dict — a single verifier still goes inside a
+  one-element list.
+- An invalid `Authorization` header is `401` and does **not** fall back to the
+  session cookie.
+- The auth symbols (`AuthMixin`, `PasswordMethod`, `OidcMethod`, `ApiKeyStore`,
+  `FileApiKeyStore`, `UserStore`, `FileUserStore`, `AuthCore`, `AuthMethod`) are
+  importable from `genro_asgi`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,50 @@
+# How-to Guides
+
+> **Status:** 🔴 DA REVISIONARE
+
+Task-focused recipes for the capabilities genro-asgi grows on top of the core.
+Each one assumes you have read [Getting started](../getting-started.md) and
+[Core concepts](../concepts.md).
+
+```{toctree}
+:hidden:
+
+authentication
+sessions
+openapi
+mcp
+tasks
+streaming
+middleware
+```
+
+## The guides
+
+- **[Authentication](authentication.md)** — configure basic / bearer / JWT
+  backends and API keys, protect routes with `auth_rule`, and work with the
+  `Avatar` identity.
+- **[Sessions](sessions.md)** — arm the session subsystem, choose a memory or
+  file store, control the session cookie, and attach an avatar at login.
+- **[OpenAPI & Swagger](openapi.md)** — turn `@route` methods into an OpenAPI 3.1
+  schema and a Swagger UI under the `_meta` prefix, direct or mounted.
+- **[MCP](mcp.md)** — expose routes as tools an AI agent can call over MCP
+  Streamable HTTP, standalone or side-by-side with REST.
+- **[Background tasks](tasks.md)** — arm the task backbone, fire off
+  fire-and-forget work, schedule interval/cron jobs, and manage them over HTTP.
+- **[Streaming & SSE](streaming.md)** — return chunked bodies with
+  `StreamingResponse` and Server-Sent Events with `SseStream`.
+- **[Middleware](middleware.md)** — the built-in chain, its order and defaults,
+  how to arm each stage, and how to register a custom middleware.
+
+## How each guide is structured
+
+Every how-to follows the same six-part shape, so you can skim to the part you
+need:
+
+1. **What it does** — the capability in one or two sentences.
+2. **When to use it** — the situation that calls for it.
+3. **Setup** — the constructor kwargs or base class you need in place.
+4. **Minimal snippet** — the smallest copy-pasteable example that works.
+5. **How to verify it** — a concrete check (a `curl`, a request, an observed
+   effect) that proves it is working.
+6. **Gotchas** — the sharp edges worth knowing before you hit them.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,107 @@
+# MCP
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Exposes your `@route` methods as **tools an AI agent can call** over the Model
+Context Protocol (MCP), served as JSON-RPC over Streamable HTTP. Because
+genro-routes is protocol-neutral, the same route tree can answer REST and MCP at
+once.
+
+## When to use it
+
+When you want an AI agent to invoke your application's operations as tools —
+either as a pure MCP endpoint or side-by-side with a REST/OpenAPI face.
+
+## Setup
+
+Two base classes cover the two shapes:
+
+- **`McpApplication`** — the whole application is a single JSON-RPC MCP endpoint.
+
+  ```python
+  from genro_asgi import McpApplication
+  app = McpApplication(routing_class=..., mount_name="mcp")
+  ```
+
+- **`McpOpenApiApplication`** — a dual-faced application: a REST/OpenAPI face
+  *and* an MCP face served on `/mcp`. The MCP segment is configurable via
+  `mcp_name_segment="mcp"`.
+
+  ```python
+  from genro_asgi import McpOpenApiApplication
+  # subclass of OpenApiApplication: REST + OpenAPI + MCP on /mcp
+  ```
+
+Both are importable from `genro_asgi`.
+
+## Marking a route as a tool
+
+Expose a method as an MCP tool with `channel_channels`:
+
+```python
+from genro_routes import route
+
+
+class Calc(McpOpenApiApplication):
+    openapi_info = {"title": "Calc", "version": "1.0.0"}
+
+    @route(channel_channels="mcp")
+    def add(self, a: int = 0, b: int = 0) -> dict:
+        return {"result": a + b}
+
+    @route(channel_channels="mcp,rest")
+    def mul(self, a: int = 0, b: int = 0) -> dict:
+        return {"result": a * b}
+```
+
+- `channel_channels="mcp"` — the method is an MCP tool only.
+- `channel_channels="mcp,rest"` — the method is **both** an MCP tool and a REST
+  endpoint (dual). This is the point of protocol-neutral routing: one method,
+  two transports, one parameter-handling path.
+
+## The `/mcp` endpoint
+
+The MCP face speaks JSON-RPC on `/mcp`, protocol version `2025-11-25`:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+- `ping`
+
+Parameter handling for `tools/call` is the same as for REST: the arguments bind
+to the method signature, typed and with defaults.
+
+A `GET` on `/mcp` opens an SSE push stream (see [streaming](streaming.md)). It
+returns `405` if the server has no task backbone armed.
+
+## How to verify it
+
+List the tools with a JSON-RPC call:
+
+```console
+$ curl -X POST http://127.0.0.1:8000/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call one:
+
+```bash
+curl -X POST http://127.0.0.1:8000/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+         "params":{"name":"add","arguments":{"a":2,"b":3}}}'
+```
+
+## Gotchas
+
+- Only routes carrying `channel_channels` that includes `"mcp"` appear as tools.
+  A plain `@route()` is REST-only and is not offered to the agent.
+- `GET /mcp` (the SSE push stream) is `405` unless the server has tasks armed —
+  see the [tasks guide](tasks.md).
+- The MCP JSON-RPC lives on `/mcp` (segment configurable via
+  `mcp_name_segment`), separate from the OpenAPI `_meta` prefix.
+- `McpApplication`, `McpOpenApiApplication`, `McpEngine` and `McpError` are
+  importable from `genro_asgi`.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,0 +1,129 @@
+# Middleware
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Wraps request handling in an ordered chain of cross-cutting stages — error
+handling, CORS, logging, sessions, auth, and well-known endpoints. Each stage is
+an object that always exists; you arm it through config.
+
+## When to use it
+
+Whenever you need behaviour that applies across routes rather than inside a single
+handler: turning exceptions into clean responses, adding CORS headers, logging
+requests, and so on. Most stages are off by default and armed with the
+`middleware` kwarg.
+
+## The built-in chain
+
+The registry ships these middleware, with a priority and a default state.
+**Lower priority number = more outer** (runs first on the way in, last on the way
+out):
+
+| Name        | Priority | Default | Notes                                        |
+|-------------|----------|---------|----------------------------------------------|
+| `errors`    | 100      | **on**  | maps exceptions and unmatched paths to status codes |
+| `wellknown` | 150      | off     | `.well-known` endpoints                       |
+| `logging`   | 200      | off     | request logging                              |
+| `cors`      | 300      | off     | CORS headers                                 |
+| `session`   | 400      | off     | armed automatically by `SessionMixin`        |
+| `auth`      | 450      | off     | armed automatically by `AuthMixin`           |
+
+Only the `http` scope is processed by the chain.
+
+Two of these arm themselves as a side effect: passing `session_store`/`session_ttl`
+arms `session`, and passing `auth=...` arms `auth`. You rarely toggle those two
+directly.
+
+## Setup — arming a stage
+
+Pass the `middleware` kwarg. A value of `True` arms a stage with its defaults; a
+dict arms it with options; `False` disarms it.
+
+```python
+from genro_asgi import AsgiServer, RoutedApplication
+from genro_routes import route
+
+
+class App(RoutedApplication):
+    @route()
+    def index(self) -> dict:
+        return {"ok": True}
+
+
+server = AsgiServer(
+    primary=App(),
+    middleware={
+        "cors": True,
+        "logging": True,
+    },
+)
+server.serve(host="127.0.0.1", port=8000)
+```
+
+## CORS options
+
+`cors` accepts an options dict:
+
+```python
+server = AsgiServer(
+    primary=App(),
+    middleware={"cors": {
+        "allow_origins": ["https://example.com"],
+        "allow_credentials": True,
+        "max_age": 600,
+    }},
+)
+```
+
+## Custom middleware
+
+Register your own middleware class in the registry, then arm it like any built-in
+stage:
+
+```python
+from genro_asgi import BaseMiddleware
+
+
+class StampMiddleware(BaseMiddleware):
+    ...
+
+
+server = AsgiServer(
+    primary=App(),
+    middleware_registry={"stamp": StampMiddleware},
+    middleware={"stamp": {...}},
+)
+```
+
+- `middleware_registry={"stamp": StampMiddleware}` teaches the server the new
+  name.
+- `middleware={"stamp": {...}}` arms it (and passes its options).
+
+The individual built-in middleware classes are importable from
+`genro_asgi.middleware` (e.g. `from genro_asgi.middleware import
+CORSMiddleware`), and `BaseMiddleware` / `MiddlewareMixin` from `genro_asgi`.
+
+## How to verify it
+
+With `cors` armed, a request carrying an `Origin` gets CORS headers back:
+
+```console
+$ curl -i -H "Origin: https://example.com" http://127.0.0.1:8000/index
+HTTP/1.1 200 OK
+access-control-allow-origin: https://example.com
+```
+
+With `logging` armed, requests appear in the server's log output.
+
+## Gotchas
+
+- `errors` is the only stage on by default — it is why an unknown path is a clean
+  `404` in the hello-world. The rest are off until you arm them.
+- An unknown middleware name in `middleware={...}` raises `ValueError`. If you are
+  arming a custom stage, register it in `middleware_registry` first.
+- Ordering is by priority, lower = more outer. A custom stage lands according to
+  its own priority in the chain.
+- Do not hand-arm `session`/`auth` when you are already passing
+  `session_store`/`auth` — those kwargs arm the respective middleware for you.

--- a/docs/guides/openapi.md
+++ b/docs/guides/openapi.md
@@ -1,0 +1,97 @@
+# OpenAPI & Swagger
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Turns your ordinary `@route` methods into an OpenAPI 3.1 schema and a Swagger UI,
+generated from the method signatures. No separate schema to maintain — the
+routes *are* the spec.
+
+## When to use it
+
+When you want a documented, browsable REST API. Subclass `OpenApiApplication`
+instead of `RoutedApplication`, declare `openapi_info`, and enable the plugins.
+
+## Setup
+
+Two things are needed: the base class and the plugins.
+
+```python
+from genro_asgi import AsgiServer, OpenApiApplication
+from genro_routes import route
+
+
+class Shop(OpenApiApplication):
+    openapi_info = {"title": "Shop API", "version": "1.0.0"}
+
+    @route()
+    def search(self, q: str = "", max_price: float = 100.0) -> dict:
+        return {"query": q, "hits": []}
+
+
+server = AsgiServer(primary=Shop(), plugins={"openapi": True, "pydantic": True})
+server.serve(host="127.0.0.1", port=8000)
+```
+
+- `openapi_info` is a class attribute carrying at least `title` and `version`.
+- `plugins={"openapi": True, "pydantic": True}` arms the OpenAPI generation and
+  pydantic-based validation.
+
+`OpenApiApplication` also accepts these keyword arguments:
+
+- `docs="swagger" | "off"` — whether to serve the Swagger UI.
+- `api_name="api"` — the name of the API sub-tree.
+- `routing_class=<instance>` — supply the routed application to expose.
+- `module="pkg.mod:Cls"` — load the routed application from a module path.
+
+## The `_meta` URLs
+
+The generated documentation lives under the **`_meta`** prefix (direct mode, when
+the OpenAPI app is the primary):
+
+- `GET /_meta/schema_json` — the OpenAPI 3.1 document.
+- `GET /_meta/docs` — the Swagger UI (returns `404` if `docs="off"`).
+- `GET /_meta/index` — a splash HTML page.
+
+Your endpoints themselves are served directly, e.g. `GET /search?q=moka`.
+
+## Direct vs mounted mode
+
+**Direct mode** — the `OpenApiApplication` is the primary; endpoints are at the
+root and meta is at `/_meta/...` (as above).
+
+**Mounted mode** — the app is placed on a URL prefix:
+
+```python
+api = OpenApiApplication(mount_name="mount", routing_class=SubApi())
+```
+
+- the endpoints are served under `/mount/api/...`
+- the meta is served under `/mount/_meta/...`
+
+## How to verify it
+
+```console
+$ curl "http://127.0.0.1:8000/search?q=moka&max_price=30"
+{"query": "moka", "hits": []}
+
+$ curl http://127.0.0.1:8000/_meta/schema_json
+{"openapi": "3.1.0", ...}
+```
+
+Open `http://127.0.0.1:8000/_meta/docs` in a browser for the interactive Swagger
+UI.
+
+## Gotchas
+
+- The documentation prefix is **`_meta`**, not `openapi`. Every meta URL is
+  `/_meta/...`.
+- Swagger requires the plugins to be armed — `plugins={"openapi": True,
+  "pydantic": True}`. Without them the schema and UI are not generated.
+- `GET /_meta/docs` returns `404` when the app was created with `docs="off"`.
+- The `_server` app has its own OpenAPI view of the system endpoints at
+  `/_server/_meta/schema_json` and `/_server/_meta/docs` — separate from your
+  app's.
+- Because routing is protocol-neutral, the very same `@route` methods can also be
+  exposed as MCP tools; see the [MCP guide](mcp.md).

--- a/docs/guides/sessions.md
+++ b/docs/guides/sessions.md
@@ -1,0 +1,128 @@
+# Sessions
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Gives a caller continuity across requests: a session cookie identifies a stored
+`Session` that can hold an `Avatar` and arbitrary data, reconnected on every
+request through the cookie.
+
+## When to use it
+
+When callers need to stay logged in, or when you want to carry per-user state
+between requests without re-authenticating each time. Arm the session subsystem
+and it keeps a store, sets the cookie, and rehydrates the session for you.
+
+## Setup
+
+Sessions are a mixin capability of `AsgiServer` (`SessionMixin`). Arming it wires
+the session middleware automatically. The relevant constructor kwargs are:
+
+- `session_store` — the backing store; `None` defaults to `MemorySessionStore`.
+- `session_ttl` — the session lifetime.
+
+```python
+from genro_asgi import AsgiServer, RoutedApplication, MemorySessionStore
+from genro_routes import route
+
+
+class App(RoutedApplication):
+    @route()
+    def index(self) -> dict:
+        return {"ok": True}
+
+
+server = AsgiServer(primary=App(), session_store=MemorySessionStore())
+server.serve(host="127.0.0.1", port=8000)
+```
+
+## Choosing a store
+
+Two stores ship with genro-asgi:
+
+- **`MemorySessionStore`** — sessions live in the process. Simple, fast, lost on
+  restart. Good for development and single-process deployments.
+- **`FileSessionStore`** — sessions persist on disk, backed by a `LocalStorage`:
+
+  ```python
+  from genro_asgi import FileSessionStore
+  # FileSessionStore(LocalStorage(...))
+  ```
+
+Both are importable from `genro_asgi`.
+
+## The session cookie
+
+Cookie behaviour is controlled through the `session` middleware options:
+
+```python
+server = AsgiServer(
+    primary=App(),
+    session_store=MemorySessionStore(),
+    middleware={"session": {
+        "cookie_name": "session_id",
+        "secure": True,
+        "samesite": "lax",
+    }},
+)
+```
+
+The session cookie is **always** `HttpOnly`. `secure` and `samesite` are yours to
+set; `cookie_name` renames the cookie.
+
+## The Session object
+
+A `Session` carries:
+
+- `.id` — the session identifier.
+- `.data` — a `Bag` of arbitrary session data.
+- `.meta` — session metadata.
+- `.avatar` — the attached identity, if any.
+- `.dirty` — whether the session has unsaved changes.
+- `.attach_avatar(...)` — bind an `Avatar` to the session; this is what a login
+  does.
+
+## Attaching an avatar at login
+
+At the point a caller proves who they are, attach their avatar to the session so
+subsequent requests carry the identity:
+
+```python
+from genro_asgi import Avatar
+
+# inside a handler that has verified the credentials:
+session.attach_avatar(Avatar("alice", tags="admin,ops"))
+```
+
+From then on, requests bearing the session cookie resolve to that avatar — no
+`Authorization` header needed. (Remember from the [auth
+guide](authentication.md) that a valid `Authorization` header still takes
+precedence over the session.)
+
+## How to verify it
+
+The first response sets the cookie; a second request replaying it reconnects the
+same session:
+
+```console
+$ curl -i http://127.0.0.1:8000/index
+HTTP/1.1 200 OK
+set-cookie: session_id=...; HttpOnly; ...
+
+$ curl -b "session_id=..." http://127.0.0.1:8000/index
+{"ok": true}
+```
+
+## Gotchas
+
+- `MemorySessionStore` loses everything on restart and does not share across
+  processes — use `FileSessionStore` (or another backend) for anything
+  persistent.
+- The cookie is always `HttpOnly`; you cannot turn that off. You *can* set
+  `secure` and `samesite`.
+- Configure the cookie under `middleware={"session": {...}}`, not under the
+  `session_store` / `session_ttl` kwargs — those control the store and lifetime,
+  the middleware controls the cookie.
+- `SessionMixin`, `Session`, `MemorySessionStore` and `FileSessionStore` are all
+  importable from `genro_asgi`.

--- a/docs/guides/streaming.md
+++ b/docs/guides/streaming.md
@@ -1,0 +1,97 @@
+# Streaming & SSE
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Sends a response body incrementally instead of all at once. `StreamingResponse`
+streams arbitrary chunks; `SseStream` streams Server-Sent Events with the correct
+SSE framing and headers.
+
+## When to use it
+
+When the body is large, generated lazily, or open-ended: a file too big to buffer,
+a progress feed, live updates pushed to the browser. Use `StreamingResponse` for
+raw chunks and `SseStream` for an event stream a browser's `EventSource` can
+consume.
+
+## Setup
+
+Both types import from submodules — they are **not** re-exported from the package
+top level:
+
+```python
+from genro_asgi.streaming import StreamingResponse
+from genro_asgi.sse import SseStream
+```
+
+## Chunked streaming
+
+Return a `StreamingResponse` fed by an async generator that yields bytes:
+
+```python
+from genro_asgi.streaming import StreamingResponse
+
+
+async def chunks():
+    yield b"one"
+    yield b"two"
+
+
+resp = StreamingResponse(chunks(), media_type="text/plain")
+```
+
+Each yielded chunk is sent as it is produced, so the client starts receiving
+before the generator finishes.
+
+## Server-Sent Events
+
+Wrap an async source of events in an `SseStream` and turn it into a response:
+
+```python
+from genro_asgi.sse import SseStream
+
+
+async def source(*evts):
+    for e in evts:
+        yield e
+
+
+stream = SseStream(source({"data": "a"}, {"data": "b"}), retry_ms=5000)
+resp = stream.response()   # a StreamingResponse with the SSE headers set
+```
+
+- The source yields event dicts (`{"data": ...}`).
+- `retry_ms` sets the client's reconnection hint.
+- `.response()` returns a `StreamingResponse` already carrying the SSE headers, so
+  you return it like any other response.
+
+## How to verify it
+
+For chunked output:
+
+```console
+$ curl -N http://127.0.0.1:8000/<your-route>
+onetwo
+```
+
+For SSE, `curl -N` shows the event frames as they arrive:
+
+```console
+$ curl -N http://127.0.0.1:8000/<your-sse-route>
+data: a
+
+data: b
+```
+
+The `-N` flag disables curl's buffering so you see chunks as they come.
+
+## Gotchas
+
+- Import from the submodules: `from genro_asgi.streaming import
+  StreamingResponse` and `from genro_asgi.sse import SseStream`. Neither is
+  available as `from genro_asgi import ...`.
+- `SseStream` produces a `StreamingResponse` via `.response()` — that is what you
+  return; do not return the `SseStream` itself.
+- The MCP push stream (`GET /mcp`) is built on this same SSE machinery; it depends
+  on the task backbone being armed (see [tasks](tasks.md) and [MCP](mcp.md)).

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,0 +1,110 @@
+# Background Tasks
+
+> **Status:** 🔴 DA REVISIONARE
+
+## What it does
+
+Runs work outside the request/response cycle: a **spool** of queued jobs, an
+**executor** that runs them, and a **scheduler** for interval and cron jobs. Tasks
+are managed over HTTP under `/_server/tasks`.
+
+## When to use it
+
+When an operation should not block the caller (send an email, crunch a report) or
+must run on a schedule (nightly cleanup, periodic sync). Arm the task backbone
+and drive it either from code or over HTTP.
+
+## Setup
+
+Tasks are a mixin capability of `AsgiServer`, armed with the `tasks` kwarg:
+
+```python
+from genro_asgi import AsgiServer, RoutedApplication
+from genro_routes import route
+
+
+class App(RoutedApplication):
+    @route()
+    def sum_sync(self, a: int = 0, b: int = 0) -> dict:
+        return {"result": a + b}
+
+
+server = AsgiServer(primary=App(), tasks=True)
+server.serve(host="127.0.0.1", port=8000)
+```
+
+`tasks` accepts:
+
+- `True` / `False` — arm or leave off.
+- a dict `{"enabled": ..., "tick_seconds": ..., "mount": ...}` for finer control.
+
+Once armed, `server.tasks` (lazily provisioned) exposes the backbone:
+`.spool`, `.executor`, `.hub`, `.scheduler`, `.task_store`, `.worker_id`.
+
+## Fire-and-forget
+
+Queue a one-off job by creating a descriptor and handing it to the spool:
+
+```python
+from genro_asgi.tasks import new_descriptor
+
+d = new_descriptor(task_id, owner="alice", mount="", node_path="sum_sync")
+server.tasks.spool.create(d, {"a": 2, "b": 3})
+```
+
+- `new_descriptor(...)` builds the task descriptor: who owns it (`owner`), which
+  mount it targets (`mount`), and which route to run (`node_path`).
+- `spool.create(descriptor, params)` enqueues it with its call parameters.
+
+The `tasks` symbols (`TaskManager`, `new_descriptor`, and the rest) import from
+`genro_asgi.tasks`, not the top level.
+
+## Scheduling
+
+Register a route as a scheduled task directly on the decorator:
+
+```python
+@route(task="cleanup", task_every="1s")
+def cleanup(self) -> dict:
+    return {"cleaned": True}
+```
+
+- `task="cleanup"` — the task code.
+- `task_every="1s"` — run on an interval. Use `task_cron=...` instead for a cron
+  expression.
+
+The scheduler drives them; from code you can call `scheduler.tick()` to advance it
+and `scheduler.run_now(code)` to trigger a scheduled task immediately.
+
+## Managing tasks over HTTP
+
+The `_server` app exposes the task backbone under `/_server/tasks/...`:
+
+- schedule side: `list`, `create`, `enable`, `disable`, `run_now`, `logs`.
+- spool side: `spool_list`, `progress`, `cancel`, `result`.
+
+## How to verify it
+
+```console
+$ curl http://127.0.0.1:8000/_server/tasks/list
+```
+
+Queue a fire-and-forget job from code (as above), then poll its progress and
+result:
+
+```console
+$ curl http://127.0.0.1:8000/_server/tasks/spool_list
+$ curl "http://127.0.0.1:8000/_server/tasks/progress?..."
+$ curl "http://127.0.0.1:8000/_server/tasks/result?..."
+```
+
+## Gotchas
+
+- The task symbols come from `genro_asgi.tasks` — `from genro_asgi.tasks import
+  new_descriptor`, not from the package top level.
+- `server.tasks` is lazy: reaching for it before `tasks` is armed will not give
+  you a live backbone. Arm it with `tasks=True` (or a config dict).
+- Interval vs cron is `task_every=...` **or** `task_cron=...` on `@route`, not
+  both.
+- The MCP push stream (`GET /mcp`) depends on the task backbone — it is `405`
+  without it. See the [MCP guide](mcp.md).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,44 @@
+genro-asgi documentation
+========================
+
+**genro-asgi** is a minimal ASGI server core: one instance-isolated server that
+mounts your applications, routes requests through `genro-routes
+<https://pypi.org/project/genro-routes/>`_, and grows authentication, sessions,
+background tasks, OpenAPI and MCP by composition. No globals, no module state —
+the server is an object you build, run, and throw away.
+
+New here? Start with :doc:`getting-started`. Coming from another ASGI framework?
+Read :doc:`coming-from-fastapi`.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting started
+
+   getting-started
+   concepts
+   coming-from-fastapi
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Guides
+
+   guides/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Architecture
+
+   architecture/overview
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/index
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
 ]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+    "sphinx-autodoc-typehints>=2.0",
+    "myst-parser>=2.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/genropy/genro-asgi"

--- a/src/genro_asgi/application.py
+++ b/src/genro_asgi/application.py
@@ -68,6 +68,7 @@ class BaseApplication:
 
     @server.setter
     def server(self, value: BaseServer) -> None:
+        """Assign the owning server once; a second assignment raises ``RuntimeError``."""
         if self._server is not None:
             raise RuntimeError(f"{type(self).__name__} is already owned by a server")
         self._server = value

--- a/src/genro_asgi/auth/core.py
+++ b/src/genro_asgi/auth/core.py
@@ -20,12 +20,13 @@ configured per instance from ``{'basic': ..., 'bearer': ..., 'jwt': [...]}``
 and consumed by the server-side ``AuthMixin`` (never by walking wrappers).
 
 Config sections (``_configure_<type>`` dynamic dispatch, unknown sections
-ignored):
-    basic:  ``{username: {password: "...", tags: "..."}}`` — O(1) lookup keyed
-            by the base64 ``username:password`` the Basic header carries.
-    bearer: ``{name: {token: "...", tags: "..."}}`` — O(1) lookup keyed by the
+ignored)::
+
+    basic:  {username: {password: "...", tags: "..."}} — O(1) lookup keyed
+            by the base64 username:password the Basic header carries.
+    bearer: {name: {token: "...", tags: "..."}} — O(1) lookup keyed by the
             token value.
-    jwt:    ``[{secret|public_key, algorithm, tags, name}, ...]`` — a list of
+    jwt:    [{secret|public_key, algorithm, tags, name}, ...] — a list of
             verifier configs, each tried in turn and decoded with pyjwt.
 
 ``authenticate(scope)`` reads the ``Authorization`` header via the shared


### PR DESCRIPTION
## Summary

Adds the user-facing documentation layer the project was missing. The code was
already well documented at the docstring level, but there was no README worth
reading, no docs site, and no Read the Docs setup. This PR fills that gap.

- **README** rewritten (24 → 183 lines): correct Beta status, a verified
  hello-world, a REST + OpenAPI/Swagger example, feature overview, architecture
  at a glance.
- **`docs/` Sphinx site**: getting-started, core concepts, 8 how-to guides
  (auth, sessions, OpenAPI, MCP, tasks, streaming, middleware), a
  "Coming from Starlette / FastAPI" concept-mapping page, an architecture
  overview, and an autodoc API reference covering every public symbol.
- **Read the Docs**: `.readthedocs.yaml` (v2) + a `[docs]` extra in
  `pyproject.toml`; `docs/_build/` added to `.gitignore`.
- **Docstring gaps closed**: docstring on the `server` setter
  (`application.py`); the `auth/core.py` module docstring made RST-safe
  (content unchanged) so autodoc renders it cleanly.

Every code snippet uses the real, current API (`RoutedApplication` +
`from genro_routes import route` + `AsgiServer().serve()`, OpenAPI meta prefix
`_meta`) — nothing from the legacy repo (no `AsgiApplication`, no CLI).

## Test plan

- Hello-world and OpenAPI README snippets run end-to-end against a live server
  (uvicorn + curl): routing, typed query params, JSON, 404, `_meta/schema_json`
  (OpenAPI 3.1), `_meta/docs` (Swagger UI) — all verified.
- `sphinx-build -W` (warnings as errors): 0 warnings, 89 HTML pages.
- All 59 `__all__` symbols present in the generated API reference.
- `pytest`: 876 passed. `ruff check src/`: clean.